### PR TITLE
Making 'suffix_extract' behave properly when it gets a 'suffixes' param (fixes #54) 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: urltools
 Type: Package
 Title: Vectorised Tools for URL Handling and Parsing
-Version: 1.5.1
+Version: 1.5.1.9000
 Date: 2016-08-30
 Author: Oliver Keyes [aut, cre], Jay Jacobs [aut, cre], Mark Greenaway [ctb],
     Bob Rudis [ctb], Alex Pinto [ctb], Maryam Khezrzadeh [ctb]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: urltools
 Type: Package
 Title: Vectorised Tools for URL Handling and Parsing
-Version: 1.5.1.9000
+Version: 1.5.2
 Date: 2016-08-30
 Author: Oliver Keyes [aut, cre], Jay Jacobs [aut, cre], Mark Greenaway [ctb],
     Bob Rudis [ctb], Alex Pinto [ctb], Maryam Khezrzadeh [ctb]

--- a/R/suffix.R
+++ b/R/suffix.R
@@ -142,8 +142,9 @@ suffix_extract <- function(domains, suffixes = NULL){
         stop("Expected column named \"suffixes\" in suffixes data.frame")
       }
     }
-    suffix_load(suffixes)
   }
+  suffix_load(suffixes)
+
   rev_domains <- reverse_strings(tolower(domains))
   matched_suffixes <- triebeard::longest_match(urltools_env$suff_trie, rev_domains)
   has_wildcard <- matched_suffixes %in% urltools_env$is_wildcard

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,7 @@ suffix_load <- function(suffixes = NULL){
   if(is.null(suffixes)){
     suffixes <- urltools::suffix_dataset
   }
-  cleaned_suffixes <- gsub(x = urltools::suffix_dataset, pattern = "*.", replacement = "", fixed = TRUE)
+  cleaned_suffixes <- gsub(x = suffixes, pattern = "*.", replacement = "", fixed = TRUE)
   is_wildcard <- cleaned_suffixes[which(grepl(x = urltools::suffix_dataset, pattern = "*.", fixed = TRUE))]
   assign("is_wildcard", is_wildcard, envir = urltools_env)
   assign("cleaned_suffixes", cleaned_suffixes, envir = urltools_env)

--- a/tests/testthat/test_suffixes.R
+++ b/tests/testthat/test_suffixes.R
@@ -70,9 +70,33 @@ test_that("Suffix extraction works when the domain matches a wildcard suffix and
   expect_equal(result$suffix[1], "banana.bd")
 })
 
-
 test_that("Suffix extraction works with new suffixes",{
   result <- suffix_extract("en.wikipedia.org", suffix_refresh())
+  expect_that(ncol(result), equals(4))
+  expect_that(names(result), equals(c("host","subdomain","domain","suffix")))
+  expect_that(nrow(result), equals(1))
+  
+  expect_that(result$subdomain[1], equals("en"))
+  expect_that(result$domain[1], equals("wikipedia"))
+  expect_that(result$suffix[1], equals("org"))
+})
+
+test_that("Suffix extraction works with an arbitrary suffixes database (to ensure it is loading it)",{
+  result <- suffix_extract(c("is-this-a.bananaboat", "en.wikipedia.org"), data.frame(suffixes = "bananaboat"))
+  expect_that(ncol(result), equals(4))
+  expect_that(names(result), equals(c("host","subdomain","domain","suffix")))
+  expect_that(nrow(result), equals(2))
+  
+  expect_equal(result$subdomain[1], NA_character_)
+  expect_equal(result$domain[1], "is-this-a")
+  expect_equal(result$suffix[1], "bananaboat")
+  expect_equal(result$subdomain[2], NA_character_)
+  expect_equal(result$domain[2], NA_character_)
+  expect_equal(result$suffix[2], NA_character_)
+})
+
+test_that("Suffix extraction is back to normal using the internal database when it receives suffixes=NULL",{
+  result <- suffix_extract("en.wikipedia.org", NULL)
   expect_that(ncol(result), equals(4))
   expect_that(names(result), equals(c("host","subdomain","domain","suffix")))
   expect_that(nrow(result), equals(1))


### PR DESCRIPTION
- Make `suffix_load` actually use the parameter we passed to it
- Make `suffix_extract` call `suffix_load` regardless of if it got a `suffixes` parameter
- A couple of tests to make sure we are using and abandoning the new `suffixes` file 