### PR TITLE
'url_compose' was missing a slash before path

### DIFF
--- a/src/compose.cpp
+++ b/src/compose.cpp
@@ -19,16 +19,15 @@ std::string compose::compose_single(String scheme, String domain, String port, S
   
   if(emptycheck(domain)){
     output += domain;
-    
-    if(emptycheck(port)){
-      output += ":";
-      output += port;
-    } else {
-      output += "/";
-    }
   }
   
+  if(emptycheck(port)){
+      output += ":";
+      output += port;
+    }
+  
   if(emptycheck(path)){
+    output += "/";
     output += path;
   }
   

--- a/tests/testthat/test_parsing.R
+++ b/tests/testthat/test_parsing.R
@@ -32,7 +32,7 @@ test_that("Parsing does not up and die and misplace the fragment",{
 })
 
 test_that("Composing works",{
-  url <- "http://foo.bar.baz/qux/"
+  url <- c("http://foo.bar.baz/qux/", "https://en.wikipedia.org:4000/wiki/api.php")
   amended_url <- url_compose(url_parse(url))
   expect_that(url, equals(amended_url))
 })


### PR DESCRIPTION
in the case where there as a nonempty port.

Here is an example of the issue:
```
url_compose(url_parse("http://localhost:8080/stuff"))
[1] "http://localhost:8080stuff"
```