### PR TITLE
param_get extracts all parameters by default and  handles &amp;,  # in values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Vectorised Tools for URL Handling and Parsing
 Version: 1.7.0
 Date: 2017-08-29
 Author: Oliver Keyes [aut, cre], Jay Jacobs [aut, cre], Drew Schmidt [aut],
-    Mark Greenaway [ctb], Bob Rudis [ctb], Alex Pinto [ctb], Maryam Khezrzadeh [ctb], 
+    Mark Greenaway [ctb], Bob Rudis [ctb], Alex Pinto [ctb], Maryam Khezrzadeh [ctb], Peter Meilstrup [ctb],
     Adam M. Costello [cph], Jeff Bezanson [cph]
 Maintainer: Oliver Keyes <ironholds@gmail.com>
 Description: A toolkit for all URL-handling needs, including encoding and decoding,

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ FEATURES
 from URLs, as appropriate (#64)
 * A small performance improvement to parameter-related functions.
 * The long-deprecated url_parameters has been removed
+* param_get() can retrieve all available parameters.
 
 BUGS
 * url_parse now handles URLs with user auth/ident information in them, stripping it out (#64)
@@ -14,6 +15,7 @@ BUGS
 * url_compose now handles URLs with query strings but no paths (#71)
 * param_set() can now handle parameters with overlapping names
 * url_parse now handles URLs with >6 character schemes (#81)
+* param_get() skips the URL fragment and handles values containing "&amp;".
 
 Version 1.6.0
 -------------------------------------------------------------------------

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,7 +45,8 @@ get_credentials <- function(urls) {
 #'
 #'@param urls a vector of URLs
 #'
-#'@param parameter_names a vector of parameter names
+#'@param parameter_names a vector of parameter names. If \code{NULL} (default), will extract
+#'all parameters that are present.
 #'
 #'@return a data.frame containing one column for each provided parameter name. Values that
 #'cannot be found within a particular URL are represented by an NA.
@@ -61,7 +62,7 @@ get_credentials <- function(urls) {
 #'@aliases param_get url_parameter
 #'@rdname param_get
 #'@export
-param_get <- function(urls, parameter_names) {
+param_get <- function(urls, parameter_names = NULL) {
     .Call(`_urltools_param_get`, urls, parameter_names)
 }
 

--- a/man/param_get.Rd
+++ b/man/param_get.Rd
@@ -5,12 +5,13 @@
 \alias{url_parameter}
 \title{get the values of a URL's parameters}
 \usage{
-param_get(urls, parameter_names)
+param_get(urls, parameter_names = NULL)
 }
 \arguments{
 \item{urls}{a vector of URLs}
 
-\item{parameter_names}{a vector of parameter names}
+\item{parameter_names}{a vector of parameter names. If \code{NULL} (default), will extract
+all parameters that are present.}
 }
 \value{
 a data.frame containing one column for each provided parameter name. Values that

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -53,13 +53,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // param_get
-List param_get(CharacterVector urls, CharacterVector parameter_names);
+List param_get(CharacterVector urls, Nullable<CharacterVector> parameter_names);
 RcppExport SEXP _urltools_param_get(SEXP urlsSEXP, SEXP parameter_namesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type urls(urlsSEXP);
-    Rcpp::traits::input_parameter< CharacterVector >::type parameter_names(parameter_namesSEXP);
+    Rcpp::traits::input_parameter< Nullable<CharacterVector> >::type parameter_names(parameter_namesSEXP);
     rcpp_result_gen = Rcpp::wrap(param_get(urls, parameter_names));
     return rcpp_result_gen;
 END_RCPP

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -47,6 +47,8 @@ private:
    * 
    */
   std::string remove_parameter_single(std::string url, CharacterVector params);
+
+  std::deque< std::string > get_parameter_names_single(std::string url);
   
 public:
   
@@ -61,7 +63,15 @@ public:
    * @return a vector of the values for that component.
    */
   CharacterVector get_parameter(CharacterVector& urls, std::string component);
-  
+
+  /**
+   * Scan a list of URLS for parameter names used.
+   *
+   * @param A reference to a character vector of urls
+   *
+   * @return a vector of unique parameter names.
+   */
+  CharacterVector get_parameter_names(CharacterVector &urls);
   
   /**
    * Set the value of a single key=value parameter for a vector of strings.

--- a/tests/testthat/test_parameters.R
+++ b/tests/testthat/test_parameters.R
@@ -7,13 +7,39 @@ test_that("Parameter parsing can handle multiple, non-existent and pre-trailing 
   results <- param_get(urls, c("api_params","hiphop"))
   expect_that(results[1:2,1], equals(c("parsable","parsable")))
   expect_true(is.na(results[3,1]))
-  
 })
 
 test_that("Parameter parsing works where the parameter appears earlier in the URL", {
   url <- param_get("www.housetrip.es/tos-de-vacaciones/geo?from=01/04/2015&guests=4&to=05/04/2015","to")
   expect_that(ncol(url), equals(1))
   expect_that(url$to[1], equals("05/04/2015"))
+})
+
+test_that("Default argument will get all parameter keys", {
+  url <- param_get("www.housetrip.es/tos-de-vacaciones/geo?from=01/04/2015&guests=4&to=05/04/2015")
+  df <- data.frame("from"="01/04/2015", "guests"="4", "to"="05/04/2015", stringsAsFactors = FALSE)
+  testthat::expect_equivalent(url, df)
+})
+
+test_that("vectorized get all keys produces NA appropriately", {
+  urls <- c("www.housetrip.es/tos-de-vacaciones/geo?guests=4&to=05/04/2015",
+            "www.housetrip.es/tos-de-vacaciones/geo?from=01/04/2015&guests=8")
+
+  pars <- param_get(urls)
+  df <- data.frame(stringsAsFactors = FALSE,
+                   from = c(NA, "01/04/2015"),
+                   guests = c("4", "8"),
+                   to = c("05/04/2015", NA))
+
+  expect_equivalent(pars, df)
+})
+
+test_that("parameter get deals with escaped ampersands and fragments in field values", {
+  par <- param_get("http://host/query?foo=bar&amp;baz&amp=nonsense#a=1&b=2", "amp")
+  expect_equivalent(par, data.frame(amp="nonsense", stringsAsFactors=FALSE))
+  
+  par <- param_get("http://host/query?foo=bar&amp;baz&amp=nonsense#a=1&b=2")
+  expect_equivalent(par, data.frame(amp="nonsense", foo="bar&amp;baz", stringsAsFactors=FALSE))
 })
 
 test_that("Setting parameter values works", {
@@ -64,4 +90,3 @@ test_that("Removing parameter keys works when there is no query", {
   expect_true(param_remove("https://en.wikipedia.org/api.php", "baz") ==
               "https://en.wikipedia.org/api.php")
 })
-


### PR DESCRIPTION
* When `get_param(urls, parameter_names = NULL)`, scan for all available parameters.
* Retrieve the whole parameter value in cases like `get_param("http://foo.bar/?field=value&amp;more", "field")`
* Don't retrieve the fragment as part of a parameter in cases like `get_param("http://foo.bar/?field=value#fragment", "field")`