### PR TITLE
suffix_load deals with array instead of df

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,6 +3,7 @@ urltools_env <- new.env(parent = emptyenv())
 suffix_load <- function(suffixes = NULL){
   if(is.null(suffixes)){
     suffixes <- urltools::suffix_dataset
+    suffixes <- suffixes$suffixes
   }
   cleaned_suffixes <- gsub(x = suffixes, pattern = "*.", replacement = "", fixed = TRUE)
   is_wildcard <- cleaned_suffixes[which(grepl(x = suffixes, pattern = "*.", fixed = TRUE))]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,8 +4,8 @@ suffix_load <- function(suffixes = NULL){
   if(is.null(suffixes)){
     suffixes <- urltools::suffix_dataset
   }
-  cleaned_suffixes <- gsub(x = suffixes$suffixes, pattern = "*.", replacement = "", fixed = TRUE)
-  is_wildcard <- cleaned_suffixes[which(grepl(x = suffixes$suffixes, pattern = "*.", fixed = TRUE))]
+  cleaned_suffixes <- gsub(x = suffixes, pattern = "*.", replacement = "", fixed = TRUE)
+  is_wildcard <- cleaned_suffixes[which(grepl(x = suffixes, pattern = "*.", fixed = TRUE))]
   suff_trie <- triebeard::trie(keys = reverse_strings(paste0(".", cleaned_suffixes)),
                                values = cleaned_suffixes)
   return(list(suff_trie = suff_trie,


### PR DESCRIPTION
Fixes a bug. If suffixes was provided to `suffix_extract` it would pass suffixes$suffixes to `suffix_load` but unfortunately `suffix_load` seemed to expect a df and does `suffixes$suffixes` on an array which threw an exception: `Error in suffixes$suffixes : $ operator is invalid for atomic vectors`