### PR TITLE
Don't include alloca.h on OpenBSD

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -24,9 +24,9 @@
 #include <malloc.h>
 #define snprintf _snprintf
 #else
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
 #include <alloca.h>
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ or __OpenBSD__ */
 #endif
 #include <assert.h>
 


### PR DESCRIPTION
Fix compilation on OpenBSD. This probably can be extended to all BSDs, (e.g. `#ifndef BSD`) but I don't have other OSs on which to test.
Tested on OpenBSD 6.6 with clang v8.0.1 and gcc v8.3.0.