### PR TITLE
Fix link to Code of Conduct in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cases, the functions are designed to be content-safe (not breaking on unexpected
 and fully vectorised, resulting in a dramatic speed improvement over existing implementations -
 crucial for large datasets. For more information, see the [urltools vignette](https://github.com/Ironholds/urltools/blob/master/vignettes/urltools.Rmd).
 
-Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md).
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
 ### Installation


### PR DESCRIPTION
A very minor comment/change.

Looks like the link to the code of conduct was ending in a 404.

Concurrently it seems like both vi & the github web editor would like to address the missing newline at the end of the file, though that seems rather unimportant after all :)