### PR TITLE
Patch for issue #108

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -106,7 +106,9 @@ get_credentials <- function(urls) {
 #'@rdname encoder
 #'@export
 url_decode <- function(urls) {
-    .Call(`_urltools_url_decode`, urls)
+    url <- .Call(`_urltools_url_decode`, urls)
+    Encoding(url) <- 'UTF-8'
+    return(url)
 }
 
 #'@rdname encoder

--- a/tests/testthat/test_encoding.R
+++ b/tests/testthat/test_encoding.R
@@ -16,11 +16,12 @@ test_that("Check decoding can handle NAs", {
   expect_that(url_decode(c("https://foo.org/bar%2f", NA)), equals(c("https://foo.org/bar/", NA)))
 })
 
-# Add comment for windows trickery
+# Windows should work as well after patch for issue #108
 test_that("Check decoding and encoding are equivalent", {
-  if(.Platform$OS.type == "unix"){
+  if(.Platform$OS.type %in% c("unix", "windows")){
     url <- "Hinrichtung_auf_dem_Altst%c3%a4dter_Ring.JPG%2f120px-Hinrichtung_auf_dem_Altst%c3%a4dter_Ring.JPG"
     decoded_url <- "Hinrichtung_auf_dem_Altst\xc3\xa4dter_Ring.JPG/120px-Hinrichtung_auf_dem_Altstädter_Ring.JPG"
+    Encoding(decoded_url) <- 'UTF-8'
     expect_that((url_decode(url)), equals((decoded_url)))
     expect_that((url_encode(decoded_url)), equals((url)))
   }


### PR DESCRIPTION
Set encoding of return of decode_url
I'm not sure whether this can be done more efficiently in C++